### PR TITLE
Update for container vulnerabilities in v1.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:1.20.2-alpine
+FROM nginxinc/nginx-unprivileged:1.23-alpine
 # Fix for broken build on Docker in GH is to put RUN true between multiple COPY statements :(
 RUN true
 COPY *.html /usr/share/nginx/html/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-web"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 9000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.02
+VERSION ?= 1.08.03
 NAME ?= "openrmf-web"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 9000

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 							<div class="card-box noradius noborder bg-warning">
 								<i class="fa fa-code float-right text-white"></i>
 								<h6 class="text-white text-uppercase m-b-20">Version</h6>
-								<h1 class="m-b-20 text-white">1.8.2</h1>
+								<h1 class="m-b-20 text-white">1.8.3</h1>
 								<span class="text-white">OpenRMF<sup>&reg;</sup> OSS</span>
 							</div>
 						</div>

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 							<div class="card-box noradius noborder bg-warning">
 								<i class="fa fa-code float-right text-white"></i>
 								<h6 class="text-white text-uppercase m-b-20">Version</h6>
-								<h1 class="m-b-20 text-white">1.8.1</h1>
+								<h1 class="m-b-20 text-white">1.8.2</h1>
 								<span class="text-white">OpenRMF<sup>&reg;</sup> OSS</span>
 							</div>
 						</div>


### PR DESCRIPTION
Commits on Aug 28, 2022
[update base image and version](https://github.com/Cingulara/openrmf-web/commit/9538f210ecc269d7e04716057a072d88423b7532)

Commits on Nov 27, 2022
[update for v1.8.3](https://github.com/Cingulara/openrmf-web/commit/21e23e5b3f98ded8118f853a99ca4e78e2f92628)